### PR TITLE
[2026-04-09] - Sync content (24184752639)

### DIFF
--- a/src/Component/Entity/DocumentItemsWithPrice.php
+++ b/src/Component/Entity/DocumentItemsWithPrice.php
@@ -25,9 +25,6 @@ class DocumentItemsWithPrice extends Entity
     protected ?string $additionalField;
     protected ItemPrice $itemPrice;
     protected ItemPrice $unitPrice;
-
-    /** @deprecated */
-    protected ?ItemPrice $buyPrice;
     protected ?ItemPrice $purchasePrice;
     protected ?DisplayPrices $displayPrices;
     protected int $itemId;
@@ -186,23 +183,6 @@ class DocumentItemsWithPrice extends Entity
     public function setUnitPrice(ItemPrice $unitPrice): static
     {
         $this->unitPrice = $unitPrice;
-        return $this;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function getBuyPrice(): ?ItemPrice
-    {
-        return $this->buyPrice;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function setBuyPrice(?ItemPrice $buyPrice): static
-    {
-        $this->buyPrice = $buyPrice;
         return $this;
     }
 

--- a/src/Component/Entity/InvoiceItem.php
+++ b/src/Component/Entity/InvoiceItem.php
@@ -26,9 +26,6 @@ class InvoiceItem extends Entity
     protected ?string $additionalField;
     protected ItemPrice $itemPrice;
     protected ItemPrice $unitPrice;
-
-    /** @deprecated */
-    protected ?ItemPrice $buyPrice;
     protected ?ItemPrice $purchasePrice;
     protected ?DisplayPrices $displayPrices;
     protected ?RecyclingFee $recyclingFee;
@@ -199,23 +196,6 @@ class InvoiceItem extends Entity
     public function setUnitPrice(ItemPrice $unitPrice): static
     {
         $this->unitPrice = $unitPrice;
-        return $this;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function getBuyPrice(): ?ItemPrice
-    {
-        return $this->buyPrice;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function setBuyPrice(?ItemPrice $buyPrice): static
-    {
-        $this->buyPrice = $buyPrice;
         return $this;
     }
 

--- a/src/Component/Entity/OrderItem.php
+++ b/src/Component/Entity/OrderItem.php
@@ -33,9 +33,6 @@ class OrderItem extends Entity
     protected ItemPrice $itemPrice;
     protected ItemPrice $unitPrice;
     protected ?DisplayPrices $displayPrices;
-
-    /** @deprecated */
-    protected ?ItemPrice $buyPrice;
     protected ?ItemPrice $purchasePrice;
     protected ?RecyclingFee $recyclingFee;
     protected ?MainImage $mainImage;
@@ -250,23 +247,6 @@ class OrderItem extends Entity
     public function setDisplayPrices(?DisplayPrices $displayPrices): static
     {
         $this->displayPrices = $displayPrices;
-        return $this;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function getBuyPrice(): ?ItemPrice
-    {
-        return $this->buyPrice;
-    }
-
-    /**
-     * @deprecated
-     */
-    public function setBuyPrice(?ItemPrice $buyPrice): static
-    {
-        $this->buyPrice = $buyPrice;
         return $this;
     }
 


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [7844d47](https://github.com/shoptet/cms4/commit/7844d4752deb7c7c80d2f8e97282188f9b162b21)

**List of changes:**
- Removing of deprecated param `buyPrice` from Accounting/Order endpoints