### PR TITLE
[2026-04-15] - Sync content (24443746885)

### DIFF
--- a/init.php
+++ b/init.php
@@ -1618,12 +1618,6 @@ require_once __DIR__ . '/src/Endpoint/Reviews/CreateProjectReviewRequest/CreateP
 require_once __DIR__ . '/src/Endpoint/Reviews/CreateProjectReviewRequest/CreateProjectReviewRequest/Data/Reaction.php';
 require_once __DIR__ . '/src/Endpoint/Reviews/CreateProjectReviewResponse/CreateProjectReviewResponse.php';
 require_once __DIR__ . '/src/Endpoint/Reviews/CreateProjectReviewResponse/CreateProjectReviewResponse/Data.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecated.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecatedResponse/GetListOfEshopReviewsDeprecatedResponse.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecatedResponse/GetListOfEshopReviewsDeprecatedResponse/Data.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecatedResponse/GetListOfEshopReviewsDeprecatedResponse/Data/Reviews.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecatedResponse/GetListOfEshopReviewsDeprecatedResponse/Data/Reviews/Item.php';
-require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfEshopReviewsDeprecatedResponse/GetListOfEshopReviewsDeprecatedResponse/Data/Reviews/Item/Reaction.php';
 require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfProductsReviews.php';
 require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfProductsReviewsDeprecated.php';
 require_once __DIR__ . '/src/Endpoint/Reviews/GetListOfProductsReviewsDeprecatedResponse/GetListOfProductsReviewsDeprecatedResponse.php';

--- a/src/Endpoint/EndpointMap.php
+++ b/src/Endpoint/EndpointMap.php
@@ -57,7 +57,6 @@ class EndpointMap
             '/api/eshop/design' => 'Shoptet\Api\Sdk\Php\Endpoint\Eshop\GetEshopDesign',
             '/api/eshop/document-settings' => 'Shoptet\Api\Sdk\Php\Endpoint\Eshop\GetEshopDocumentSettings',
             '/api/eshop/customer-fields' => 'Shoptet\Api\Sdk\Php\Endpoint\Eshop\GetEshopMandatoryFields',
-            '/api/eshop/reviews' => 'Shoptet\Api\Sdk\Php\Endpoint\Reviews\GetListOfEshopReviewsDeprecated',
             '/api/products' => 'Shoptet\Api\Sdk\Php\Endpoint\Products\GetListOfProducts',
             '/api/products/snapshot' => 'Shoptet\Api\Sdk\Php\Endpoint\Products\GetListOfAllProducts',
             '/api/products/snapshot/pricelists' => 'Shoptet\Api\Sdk\Php\Endpoint\Products\GetListOfAllProductsAndPricelistPrices',

--- a/src/Sdk.php
+++ b/src/Sdk.php
@@ -366,7 +366,6 @@ use Shoptet\Api\Sdk\Php\Endpoint\Reviews\CreateProductReview;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\CreateProductReviewRequest\CreateProductReviewRequest;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\CreateProjectReview;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\CreateProjectReviewRequest\CreateProjectReviewRequest;
-use Shoptet\Api\Sdk\Php\Endpoint\Reviews\GetListOfEshopReviewsDeprecated;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\GetListOfProductsReviews;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\GetListOfProductsReviewsDeprecated;
 use Shoptet\Api\Sdk\Php\Endpoint\Reviews\GetListOfProjectReviews;
@@ -644,28 +643,6 @@ class Sdk
     {
         return self::getEndpointFactory()
             ->createEndpoint(GetEshopMandatoryFields::class)
-            ->setQueryParams($queryParams)
-            ->execute();
-    }
-
-    /**
-     * @param array{
-     *     language?: string,
-     *     page?: int,
-     *     itemsPerPage?: int,
-     * } $queryParams
-     *
-     * @return ResponseInterface
-     *
-     * @throws LogicException
-     * @throws RuntimeException
-     *
-     * @see https://api.docs.shoptet.com/shoptet-api/openapi/Reviews/getlistofeshopreviewsdeprecated
-     */
-    public static function getListOfEshopReviewsDeprecated(array $queryParams = []): ResponseInterface
-    {
-        return self::getEndpointFactory()
-            ->createEndpoint(GetListOfEshopReviewsDeprecated::class)
             ->setQueryParams($queryParams)
             ->execute();
     }


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [e06cc05](https://github.com/shoptet/cms4/commit/e06cc055d9238db52a99a07f7cafc50462ca4b41)

**List of changes:**
- Cleanup of deprecated `getListOfEshopReviewsDeprecated` endpoint