### PR TITLE
[2026-05-18] - Sync content (26024788272)

### DIFF
--- a/src/Endpoint/Webhooks/UpdateExistingWebhookRequest/UpdateExistingWebhookRequest/Data.php
+++ b/src/Endpoint/Webhooks/UpdateExistingWebhookRequest/UpdateExistingWebhookRequest/Data.php
@@ -6,14 +6,14 @@ use Shoptet\Api\Sdk\Php\Component\Entity\Entity;
 
 class Data extends Entity
 {
-    protected string $url;
+    protected ?string $url;
 
-    public function getUrl(): string
+    public function getUrl(): ?string
     {
         return $this->url;
     }
 
-    public function setUrl(string $url): static
+    public function setUrl(?string $url): static
     {
         $this->url = $url;
         return $this;


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [1e7e77d](https://github.com/shoptet/cms4/commit/1e7e77d40d3053a5f3bcba9318678d7ce4b8f50d)

**List of changes:**
- Add support for nullable url in request of the webhook update endpoint _(Prerequisite for webhooks with payload)_.