### PR TITLE
[2026-05-27] - Sync content (26501629796)

### DIFF
--- a/src/HttpClient/CurlClient.php
+++ b/src/HttpClient/CurlClient.php
@@ -341,7 +341,6 @@ class CurlClient implements ClientInterface
     protected function closeCurlHandle(): void
     {
         if ($this->handle !== null) {
-            \curl_close($this->handle);
             $this->handle = null;
         }
     }


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [bac4c53](https://github.com/shoptet/cms4/commit/bac4c53cf7b949839cc6b6a3bd3a5bf9a87620ed)

**List of changes:**
- Improve code compatibility with php 8.5 - [curl_close() DEPRECATION](https://php.watch/versions/8.5/curl_close-curl_share_close-deprecated)