### PR TITLE
[2026-06-03] - Sync content (26872543470)

### DIFF
--- a/src/Endpoint/Eshop/GetEshopDocumentSettingsResponse/GetEshopDocumentSettingsResponse/Data/Order.php
+++ b/src/Endpoint/Eshop/GetEshopDocumentSettingsResponse/GetEshopDocumentSettingsResponse/Data/Order.php
@@ -15,6 +15,7 @@ class Order extends Entity
     protected ?bool $printItemRemark;
     protected ?bool $displayProductStockLocation;
     protected ?ItemRemarkParameters $itemRemarkParameters;
+    protected bool $fullVatBreakdownExport;
 
     public function getCodePrefix(): ?string
     {
@@ -101,6 +102,17 @@ class Order extends Entity
     public function setItemRemarkParameters(?ItemRemarkParameters $itemRemarkParameters): static
     {
         $this->itemRemarkParameters = $itemRemarkParameters;
+        return $this;
+    }
+
+    public function isFullVatBreakdownExport(): bool
+    {
+        return $this->fullVatBreakdownExport;
+    }
+
+    public function setFullVatBreakdownExport(bool $fullVatBreakdownExport): static
+    {
+        $this->fullVatBreakdownExport = $fullVatBreakdownExport;
         return $this;
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [f392ed0](https://github.com/shoptet/cms4/commit/f392ed0cc0393cb8e906e849c501f8c275e9860b)

**List of changes:**
- Add support for new param `fullVatBreakdownExport` in doc settings endpoint