### PR TITLE
[2026-06-05] - Sync content (27023424975)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
     reportAlwaysTrueInLastCondition: true
     checkMissingCallableSignature: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    treatPhpDocTypesAsCertain: false
 
     bootstrapFiles:
         - build/phpstan.bootstrap.php


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [5545251](https://github.com/shoptet/cms4/commit/554525122850795f57bfb27c47091a6cdaab4fe2)

**List of changes:**
- Temporarily disable `treatPhpDocTypesAsCertain` in API SDK PHPstan due to err in PHPdoc when return type of `mb_strlen()` is set as `int<1, max>` but it can also be set to 0 for empty strings