### PR TITLE
[2026-07-01] - Sync content (28505719421)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-zlib": "*"
     },
     "require-dev": {
-        "phpstan/phpstan": "^2.2.2",
+        "phpstan/phpstan": "^2.2.3",
         "php-parallel-lint/php-parallel-lint": "^1.4.0",
         "squizlabs/php_codesniffer": "^3.9",
         "contributte/qa": "^0.3.2",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,13 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: '#^Method Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\:\:filter\(\) should return static\(Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\<TValue\>\) but returns static\(Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\<TValue\>\)\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Entity/EntityCollection.php
-
-		-
-			message: '#^Method Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\:\:map\(\) should return static\(Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\<TValue\>\) but returns static\(Shoptet\\Api\\Sdk\\Php\\Component\\Entity\\EntityCollection\<TValue\>\)\.$#'
-			identifier: return.type
-			count: 1
-			path: src/Component/Entity/EntityCollection.php


### PR DESCRIPTION
> [!NOTE]
> This PR copies content from the source repo.
> Source repo commit [e5ca962](https://github.com/shoptet/cms4/commit/e5ca96209f537bccb26d5a350f4c5d3ea6d9e1d0)

**List of changes:**
- Phpstan baseline invalid error cleanup after v `2.2.3`